### PR TITLE
Added UpdateImageRequest type.

### DIFF
--- a/images.go
+++ b/images.go
@@ -39,6 +39,12 @@ type ImageRequest struct {
 	NumImages    *int   `json:"num_images,omitempty"`
 }
 
+type UpdateImageRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Frequency   string `json:"frequency,omitempty"`
+}
+
 type ImageOs struct {
 	idField
 	Architecture *int   `json:"architecture,omitempty"`
@@ -116,15 +122,10 @@ func (api *API) DeleteImage(img_id string) (*Image, error) {
 }
 
 // PUT /images/{id}
-func (api *API) UpdateImage(img_id string, new_name string, new_desc string, new_freq string) (*Image, error) {
+func (api *API) UpdateImage(img_id string, request *UpdateImageRequest) (*Image, error) {
 	result := new(Image)
-	req := struct {
-		Name        string `json:"name,omitempty"`
-		Description string `json:"description,omitempty"`
-		Frequency   string `json:"frequency,omitempty"`
-	}{Name: new_name, Description: new_desc, Frequency: new_freq}
 	url := createUrl(api, imagePathSegment, img_id)
-	err := api.Client.Put(url, &req, &result, http.StatusOK)
+	err := api.Client.Put(url, &request, &result, http.StatusOK)
 	if err != nil {
 		return nil, err
 	}

--- a/images_test.go
+++ b/images_test.go
@@ -176,7 +176,13 @@ func TestUpdateImage(t *testing.T) {
 	new_name := test_image.Name + " updated"
 	new_desc := test_image.Name + " updated"
 
-	img, err := api.UpdateImage(test_image.Id, new_name, new_desc, "ONCE")
+	imageUpdated := UpdateImageRequest{
+		Name:        new_name,
+		Description: new_desc,
+		Frequency:   "ONCE",
+	}
+
+	img, err := api.UpdateImage(test_image.Id, &imageUpdated)
 
 	if err != nil {
 		t.Errorf("UpdateImage failed. Error: " + err.Error())


### PR DESCRIPTION
Introduced UpdateImageRequest type. Having the parameters passed on independently, and then created added to a struct in the update method was causing HTTP 400 Bad Request status when called from terraform.

The following is the test output for image resource:

go test -run "^TestCreateImage|TestGetImage|TestListImages|TestListImageOs|TestUpdateImage|TestDeleteImage$" --timeout=120m
Initializing tests...
Creating test server 'TestServer_363445'...
Creating image 'TestServerImage_621'...
Getting image 'TestServerImage_621_20180511'...
Listing all images...
Listing all image Operating Systems...
Updating image 'TestServerImage_621_20180511'...
Deleting image 'TestServerImage_621_20180511'...
PASS
ok  	github.com/StackPointCloud/oneandone-cloudserver-sdk-go	1517.349s