### PR TITLE
Added block storage update method, test, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1656,6 +1656,19 @@ blcs_id, blcs, err := api.CreateBlockStorage(&request)
 `Description` and `ServerId`are optional parameters.
 
 
+**Update a block storage:**
+
+```
+request := oneandone.UpdateBlockStorageRequest {
+    Name: new_name, 
+    Description: new_desc,
+  }
+  
+blcs, err := api.UpdateBlockStorage(blcs_id, &request)
+```
+All request's parameters are optional.
+
+
 **Remove a block storage storage:**
 
 `blcs, err := api.DeleteBlockStorage(blcs_id)`

--- a/blockstorages.go
+++ b/blockstorages.go
@@ -31,6 +31,11 @@ type BlockStorageServer struct {
 	Name     string `json:"name,omitempty"`
 }
 
+type UpdateBlockStorageRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 func (api *API) ListBlockStorages(args ...interface{}) ([]BlockStorage, error) {
 	url, err := processQueryParams(createUrl(api, blockStoragePathSegment), args...)
 	if err != nil {
@@ -124,6 +129,17 @@ func (api *API) DeleteBlockStorage(id string) (*BlockStorage, error) {
 	result := new(BlockStorage)
 	url := createUrl(api, blockStoragePathSegment, id)
 	err := api.Client.Delete(url, nil, &result, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	result.api = api
+	return result, nil
+}
+
+func (api *API) UpdateBlockStorage(id string, request *UpdateBlockStorageRequest) (*BlockStorage, error) {
+	result := new(BlockStorage)
+	url := createUrl(api, blockStoragePathSegment, id)
+	err := api.Client.Put(url, &request, &result, http.StatusOK)
 	if err != nil {
 		return nil, err
 	}

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -118,7 +118,7 @@ func TestDeleteSSHKey(t *testing.T) {
 	set_ssh_key.Do(setup_ssh_key)
 	_, err := api.DeleteSSHKey(test_ssh_key.Id)
 	if err != nil {
-		t.Errorf("Error while deleting ssh key", err.Error())
+		t.Errorf(err.Error())
 		t.Fail()
 	}
 


### PR DESCRIPTION
Need this merged in order to be able to perform terraform update on name or description change.

Test output:
```
$ go test -run "^TestCreateBlockStorage|TestListBlockStorages|TestGetBlockStorage|TestAddBlockStorageServer|TestUpdateBlockStorage|TestDeleteBlockStorage|TestListSSHKeys|TestCreateSSHKey|TestRenameSSHKey|TestDeleteSSHKey$"
Initializing tests...
Creating test server 'TestServer_974605'...
Creating new block storage 'BlockStorage_713'...
Creating new block storage 'BlockStorage_638'...
Adding block storage 'BlockStorage_638' to server ...
Creating new block storage 'BlockStorage_360'...
Updating block storage 'BlockStorage_360'...
Creating test ssh_key 'SSHKEY_514'...
PASS
ok  	github.com/StackPointCloud/oneandone-cloudserver-sdk-go	179.134s
```