### PR TITLE
Updated BaremetalHardware Hdds type to array.

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -146,7 +146,7 @@ type BaremetalHardware struct {
 	CoresPerProcessor int     `json:"cores_per_processor"`
 	Ram               float32 `json:"ram"`
 	Unit              string  `json:"unit,omitempty"`
-	Hdds              Hdd     `json:"hdds,omitempty"`
+	Hdds              []Hdd   `json:"hdds,omitempty"`
 	ApiPtr
 }
 


### PR DESCRIPTION
Currently, BaremetalHardware hdds is of type Hdd, which causes unmarshaling error, because API returns an array. I've updated the type to []Hdd.